### PR TITLE
made moveToIndex a public function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 *.noie.js
 *.noie.coffee
+.idea*

--- a/coffee/jquery.film_roll.coffee
+++ b/coffee/jquery.film_roll.coffee
@@ -203,7 +203,7 @@ class @FilmRoll
     if child_index > -1
       @moveToIndex child_index
 
-  moveToIndex: (index, direction, animate = true) ->
+  moveToIndex: (index, direction, animate = true) =>
     @index = index
     @clearScroll()
     child = @children[index]

--- a/js/jquery.film_roll.js
+++ b/js/jquery.film_roll.js
@@ -23,6 +23,7 @@
       this.options = options != null ? options : {};
       this.rotateRight = __bind(this.rotateRight, this);
       this.rotateLeft = __bind(this.rotateLeft, this);
+      this.moveToIndex = __bind(this.moveToIndex, this);
       this.moveRight = __bind(this.moveRight, this);
       this.moveLeft = __bind(this.moveLeft, this);
       this.clearScroll = __bind(this.clearScroll, this);


### PR DESCRIPTION
**If** film_roll is **not** run in **document ready** the start position of the
first image is not center. If the back arrow is clicked in this
situation the film roll scrolls through all the images to display the
last.

A fix for this is to call both `configureWidth` and `moveToIndex` when
initializing the film_roll (while not in on document ready)
